### PR TITLE
Support underlines when transforming html tables back to xml

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@laws-africa/indigo-akn",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@laws-africa/indigo-akn",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Akoma Ntoso support libraries for the Indigo platform.",
   "main": "index.js",
   "scripts": {

--- a/src/xsl.js
+++ b/src/xsl.js
@@ -50,7 +50,7 @@ export const HTML_TO_AKN_XSL = `
     </p>
   </xsl:template>
 
-  <xsl:template match="html:b | html:br | html:i | html:sup | html:sub">
+  <xsl:template match="html:b | html:br | html:i | html:sup | html:sub | html:u">
     <xsl:element name="{name(.)}">
       <xsl:apply-templates />
     </xsl:element>


### PR DESCRIPTION
This is required to support underlines in the table wysiwyg editor.