### PR TITLE
Updated dom-anchor-text-quote to fix bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lawsafrica/indigo-akn",
-  "version": "5.1.1",
+  "version": "5.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -63,6 +63,15 @@
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "@lawsafrica/dom-anchor-text-quote": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@lawsafrica/dom-anchor-text-quote/-/dom-anchor-text-quote-5.0.0.tgz",
+      "integrity": "sha512-knT7dSBQbquUoaXsPyDg36fKDQevsswadiwWCao4tgrbPzKRE//lOs29AL0tUzoIF4zf/xefybP42mXjKtpF6g==",
+      "requires": {
+        "diff-match-patch": "^1.0.0",
+        "dom-anchor-text-position": "^5.0.0"
       }
     },
     "@popperjs/core": {
@@ -350,11 +359,6 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "dev": true
-    },
-    "ancestors": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/ancestors/-/ancestors-0.0.3.tgz",
-      "integrity": "sha1-Ek65RER9aLMCBXBH0V0Hep2lF50="
     },
     "ansi-regex": {
       "version": "5.0.1",
@@ -802,40 +806,6 @@
         "dom-seek": "^5.1.0"
       }
     },
-    "dom-anchor-text-quote": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/dom-anchor-text-quote/-/dom-anchor-text-quote-4.0.2.tgz",
-      "integrity": "sha1-Kh4M1OBsebC/oShK7L9wYgKPwtc=",
-      "requires": {
-        "diff-match-patch": "^1.0.0",
-        "dom-anchor-text-position": "^4.0.0"
-      },
-      "dependencies": {
-        "dom-anchor-text-position": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/dom-anchor-text-position/-/dom-anchor-text-position-4.0.0.tgz",
-          "integrity": "sha1-TIObO97ZTwyrDwagGJRo8/HsK7I=",
-          "requires": {
-            "dom-node-iterator": "^3.5.0",
-            "dom-seek": "^4.0.1"
-          }
-        },
-        "dom-seek": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/dom-seek/-/dom-seek-4.0.3.tgz",
-          "integrity": "sha1-8U3d8Es/sGLZAcewCwwUKgbgqUs=",
-          "requires": {
-            "ancestors": "0.0.3",
-            "index-of": "^0.2.0"
-          }
-        }
-      }
-    },
-    "dom-node-iterator": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/dom-node-iterator/-/dom-node-iterator-3.5.3.tgz",
-      "integrity": "sha1-MraKpECWLxc0SHAp9USj23BGN7c="
-    },
     "dom-seek": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/dom-seek/-/dom-seek-5.1.1.tgz",
@@ -1272,11 +1242,6 @@
         "pkg-dir": "^4.2.0",
         "resolve-cwd": "^3.0.0"
       }
-    },
-    "index-of": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/index-of/-/index-of-0.2.0.tgz",
-      "integrity": "sha1-OMHiNn6lXf+tO261kuwcwwkNfWU="
     },
     "inflight": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lawsafrica/indigo-akn",
-  "version": "5.1.1",
+  "version": "5.2.0",
   "description": "Akoma Ntoso support libraries for the Indigo platform.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/laws-africa/indigo-akn#readme",
   "dependencies": {
     "dom-anchor-text-position": "^5.0.0",
-    "dom-anchor-text-quote": "^4.0.2",
+    "@lawsafrica/dom-anchor-text-quote": "^5.0.0",
     "he": "^1.2.0",
     "tippy.js": "^6.3.7"
   },


### PR DESCRIPTION
Install https://github.com/laws-africa/dom-anchor-text-quote instead of upstream.

Our copy fixes a bug (https://github.com/tilgovi/dom-anchor-text-quote/issues/16) and updates the dom-anchor-text-position dependency to 5.0.0