### PR TITLE
rangeToTarget for XML

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lawsafrica/indigo-akn",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lawsafrica/indigo-akn",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "Akoma Ntoso support libraries for the Indigo platform.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
this adds the AKN XML equivalent of the existing HTML rangeToTarget functionality, so that we can convert XML ranges into XML targets. The primary differences are looking for `eId` rather than `id` and we don't need to strip foreign elements.