### PR TITLE
rangeToTarget and targetToRange support `data-eid` attributes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,10 +9,11 @@ Guidance for AI coding agents working in this repository.
 ## Common Commands
 
 - Install dependencies: `npm install`
-- Run tests: `npm test`
+- Build and run tests: `npm run build-test`
+- Run tests only: `npm test`
 - Build package output: `npm run build`
 
-The test suite is run through Karma using Chrome, Mocha, and Chai. The build command removes and regenerates `dist/`; do not hand-edit generated files in `dist/`.
+The test suite is run through Karma using Chrome, Mocha, and Chai. The build command removes and regenerates `dist/`; do not hand-edit generated files in `dist/`. Prefer `npm run build-test` for verification because tests may import built package output from `dist/`.
 
 ## Repository Layout
 
@@ -35,7 +36,7 @@ The test suite is run through Karma using Chrome, Mocha, and Chai. The build com
 
 Before handing off code changes, run the narrowest useful check:
 
-- For behavior changes, run `npm test`.
+- For behavior changes, run `npm run build-test`.
 - For build or packaging changes, run `npm run build`.
 - If you cannot run a relevant command, report why and describe the remaining risk.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ npm install @lawsafrica/indigo-akn
 ## Running tests
 
 1. Install dependencies: `npm install`
-2. Run tests: `npm test`
+2. Build and run tests: `npm run build-test`
+
+`npm run build-test` regenerates `dist/` before running the browser test suite. Use `npm test` only when `dist/` is already up to date.
 
 ## Releasing a new version
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && tsc && copyfiles --up 1 'src/**/*.js' dist",
+    "build-test": "npm run build && npm test",
     "test": "karma start karma.conf.js"
   },
   "repository": {

--- a/src/ranges.ts
+++ b/src/ranges.ts
@@ -176,15 +176,19 @@ export function withoutForeignElements (root: Element, callback: () => any, sele
  * @param root root element to look within
  */
 export function targetToRange (target: IRangeTarget, root: Element): Range | null {
+  function find (id: string): Element | null {
+    return root.querySelector(`[id="${id}"], [data-eid="${id}"]`);
+  }
+
   let anchorId = target.anchor_id;
   let ix = anchorId.lastIndexOf('__');
-  let anchor = root.querySelector(`[id="${anchorId}"]`);
+  let anchor = find(anchorId);
 
   // do our best to find the anchor node, going upwards up the id chain if the id has components
   while (!anchor && ix > -1) {
     anchorId = anchorId.substring(0, ix);
     ix = anchorId.lastIndexOf('__');
-    anchor = root.querySelector(`[id="${anchorId}"]`);
+    anchor = find(anchorId);
   }
 
   if (anchor) {
@@ -292,14 +296,15 @@ export function rangeToTarget (range: Range, root: Element): IRangeTarget | null
     }
   }
 
-  anchor = anchor.closest('[id]');
+  // look for either an id or data-eid attribute, preferring data-eid if both are present
+  anchor = anchor.closest('[id], [data-eid]');
   // bail if there's no anchor, or the anchor is outside of the root
   if (!anchor || (anchor !== root && (anchor.compareDocumentPosition(root) & Node.DOCUMENT_POSITION_CONTAINS) === 0)) {
     return null;
   }
 
   const target: IRangeTarget = {
-    anchor_id: anchor.id,
+    anchor_id: anchor.getAttribute('data-eid') || anchor.id,
     selectors: []
   };
 

--- a/tests/ranges.js
+++ b/tests/ranges.js
@@ -1,0 +1,57 @@
+import { expect } from 'chai';
+import { rangeToTarget, targetToRange } from '../src/ranges';
+
+describe('ranges', () => {
+  describe('rangeToTarget()', () => {
+    it('should anchor ranges to the closest data-eid attribute', () => {
+      const root = document.createElement('div');
+      root.innerHTML = '<section><p data-eid="sec_1__p_1">Some selected text.</p></section>';
+      document.body.appendChild(root);
+
+      try {
+        const text = root.querySelector('[data-eid]').firstChild;
+        const range = document.createRange();
+        range.setStart(text, 5);
+        range.setEnd(text, 13);
+
+        const target = rangeToTarget(range, root);
+
+        expect(target.anchor_id).to.equal('sec_1__p_1');
+        expect(target.selectors[0]).to.include({
+          type: 'TextPositionSelector',
+          start: 5,
+          end: 13
+        });
+        expect(target.selectors[1]).to.include({
+          type: 'TextQuoteSelector',
+          exact: 'selected'
+        });
+      } finally {
+        document.body.removeChild(root);
+      }
+    });
+  });
+
+  describe('targetToRange()', () => {
+    it('should resolve targets anchored to a data-eid attribute', () => {
+      const root = document.createElement('div');
+      root.innerHTML = '<section><p data-eid="sec_1__p_1">Some selected text.</p></section>';
+      document.body.appendChild(root);
+
+      try {
+        const range = targetToRange({
+          anchor_id: 'sec_1__p_1',
+          selectors: [{
+            type: 'TextPositionSelector',
+            start: 5,
+            end: 13
+          }]
+        }, root);
+
+        expect(range.toString()).to.equal('selected');
+      } finally {
+        document.body.removeChild(root);
+      }
+    });
+  });
+});

--- a/tests/ranges.js
+++ b/tests/ranges.js
@@ -1,8 +1,36 @@
 import { expect } from 'chai';
-import { rangeToTarget, targetToRange } from '../src/ranges';
+import { rangeToTarget, targetToRange } from '../dist/ranges';
 
 describe('ranges', () => {
   describe('rangeToTarget()', () => {
+    it('should anchor ranges to the closest id attribute', () => {
+      const root = document.createElement('div');
+      root.innerHTML = '<section><p id="sec_1__p_1">Some selected text.</p></section>';
+      document.body.appendChild(root);
+
+      try {
+        const text = root.querySelector('[id]').firstChild;
+        const range = document.createRange();
+        range.setStart(text, 5);
+        range.setEnd(text, 13);
+
+        const target = rangeToTarget(range, root);
+
+        expect(target.anchor_id).to.equal('sec_1__p_1');
+        expect(target.selectors[0]).to.include({
+          type: 'TextPositionSelector',
+          start: 5,
+          end: 13
+        });
+        expect(target.selectors[1]).to.include({
+          type: 'TextQuoteSelector',
+          exact: 'selected'
+        });
+      } finally {
+        document.body.removeChild(root);
+      }
+    });
+
     it('should anchor ranges to the closest data-eid attribute', () => {
       const root = document.createElement('div');
       root.innerHTML = '<section><p data-eid="sec_1__p_1">Some selected text.</p></section>';
@@ -30,9 +58,49 @@ describe('ranges', () => {
         document.body.removeChild(root);
       }
     });
+
+    it('should prefer data-eid over id when both are present', () => {
+      const root = document.createElement('div');
+      root.innerHTML = '<section><p id="rendered-id" data-eid="sec_1__p_1">Some selected text.</p></section>';
+      document.body.appendChild(root);
+
+      try {
+        const text = root.querySelector('[data-eid]').firstChild;
+        const range = document.createRange();
+        range.setStart(text, 5);
+        range.setEnd(text, 13);
+
+        const target = rangeToTarget(range, root);
+
+        expect(target.anchor_id).to.equal('sec_1__p_1');
+      } finally {
+        document.body.removeChild(root);
+      }
+    });
   });
 
   describe('targetToRange()', () => {
+    it('should resolve targets anchored to an id attribute', () => {
+      const root = document.createElement('div');
+      root.innerHTML = '<section><p id="sec_1__p_1">Some selected text.</p></section>';
+      document.body.appendChild(root);
+
+      try {
+        const range = targetToRange({
+          anchor_id: 'sec_1__p_1',
+          selectors: [{
+            type: 'TextPositionSelector',
+            start: 5,
+            end: 13
+          }]
+        }, root);
+
+        expect(range.toString()).to.equal('selected');
+      } finally {
+        document.body.removeChild(root);
+      }
+    });
+
     it('should resolve targets anchored to a data-eid attribute', () => {
       const root = document.createElement('div');
       root.innerHTML = '<section><p data-eid="sec_1__p_1">Some selected text.</p></section>';
@@ -49,6 +117,36 @@ describe('ranges', () => {
         }, root);
 
         expect(range.toString()).to.equal('selected');
+      } finally {
+        document.body.removeChild(root);
+      }
+    });
+
+    it('should resolve targets when id and data-eid differ', () => {
+      const root = document.createElement('div');
+      root.innerHTML = '<section><p id="rendered-id" data-eid="sec_1__p_1">Some selected text.</p></section>';
+      document.body.appendChild(root);
+
+      try {
+        const dataEidRange = targetToRange({
+          anchor_id: 'sec_1__p_1',
+          selectors: [{
+            type: 'TextPositionSelector',
+            start: 5,
+            end: 13
+          }]
+        }, root);
+        const idRange = targetToRange({
+          anchor_id: 'rendered-id',
+          selectors: [{
+            type: 'TextPositionSelector',
+            start: 5,
+            end: 13
+          }]
+        }, root);
+
+        expect(dataEidRange.toString()).to.equal('selected');
+        expect(idRange.toString()).to.equal('selected');
       } finally {
         document.body.removeChild(root);
       }


### PR DESCRIPTION
this is required for cases when the data-eid and the resulting id in the
dom differ, such as when law-widgets has re-written the id attribut for
defined terms. This change means that we prefer data-eid where
available, because it's more reliable.

anything that doesn't use data-eid still uses id as usual.